### PR TITLE
Don't recreate smart groups if they are unchanged.

### DIFF
--- a/CRM/Civiconfig/Entity/Group.php
+++ b/CRM/Civiconfig/Entity/Group.php
@@ -58,7 +58,8 @@ class CRM_Civiconfig_Entity_Group extends CRM_Civiconfig_Entity {
       $this->handleSavedSearch($formValues);
     }
     $this->sanitizeParams();
-    if (!array_diff($this->_apiParams, $existing) && $formValues == $existingSearch['form_values']) {
+    if (is_array($existing) && !array_diff($this->_apiParams, $existing)
+      && $formValues == $existingSearch['form_values']) {
       // No new things. We can return to save time.
       return;
     }


### PR DESCRIPTION
If you configure a lot of smart groups, Civiconfig.load_json takes a lot of time. I think the smartgroup cache is repopulated or something.

I changed a couple of things, so that load_json does not recreate smart groups if their properties and their saved searches are unchanged.

This makes Civiconfig.load_json way faster.
